### PR TITLE
Fix RagNotesAI capitalization in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # RagNotesAI
 
-RagNoteAI is a project designed to enhance the quality, coherence, and structure of user-created notes, especially
-for Obsidian, in a Retrieval-Augmented Generation (RAG) system. By leveraging cutting-edge Natural Language Processing (NLP) techniques, RagNoteAI optimizes and refines your notes for better usability, readability, and retrieval performance.
+RagNotesAI is a project designed to enhance the quality, coherence, and structure of user-created notes, especially
+for Obsidian, in a Retrieval-Augmented Generation (RAG) system. By leveraging cutting-edge Natural Language Processing (NLP) techniques, RagNotesAI optimizes and refines your notes for better usability, readability, and retrieval performance.


### PR DESCRIPTION
## Summary
- update README to consistently use the project name `RagNotesAI`

## Testing
- `ruff check .`
- `mypy --install-types --non-interactive` *(fails: Can't determine which types to install)*

------
https://chatgpt.com/codex/tasks/task_e_684247da21bc8329bbe6a846214849f4