### PR TITLE
Handle empty sync logs in status endpoint

### DIFF
--- a/app/api/status.py
+++ b/app/api/status.py
@@ -20,19 +20,28 @@ async def get_status():
         with open(SYNC_LOG_FILE, encoding="utf-8") as f:
             sync_log = json.load(f)
 
-        note_count = len(sync_log)
-        chunk_count = sum(len(v["ids"]) for v in sync_log.values())
-        last_sync = max(v.get("mtime", 0.0) for v in sync_log.values())
-        status.update({
-            "note_count": note_count,
-            "chunk_count": chunk_count,
-            "last_sync_time": datetime.fromtimestamp(last_sync).strftime('%Y-%m-%d %H:%M:%S')
-        })
+        if sync_log:
+            note_count = len(sync_log)
+            chunk_count = sum(len(v["ids"]) for v in sync_log.values())
+            last_sync = max(v.get("mtime", 0.0) for v in sync_log.values())
+            status.update({
+                "note_count": note_count,
+                "chunk_count": chunk_count,
+                "last_sync_time": datetime.fromtimestamp(last_sync).strftime(
+                    "%Y-%m-%d %H:%M:%S"
+                ),
+            })
+        else:
+            status.update({
+                "note_count": 0,
+                "chunk_count": 0,
+                "last_sync_time": None,
+            })
     else:
         status.update({
             "note_count": 0,
             "chunk_count": 0,
-            "last_sync_time": None
+            "last_sync_time": None,
         })
 
     return status

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,43 @@
+import json
+from datetime import datetime
+
+import pytest
+
+from app.api import status
+
+
+@pytest.mark.asyncio
+async def test_get_status_empty_log(tmp_path, monkeypatch):
+    log_file = tmp_path / "sync_log.json"
+    log_file.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(status, "SYNC_LOG_FILE", str(log_file))
+    monkeypatch.setattr(status, "VAULT_DIR", tmp_path)
+    monkeypatch.setattr(status, "INDEX_FILE", str(tmp_path / "index"))
+
+    result = await status.get_status()
+
+    assert result["log_exists"] is True
+    assert result["note_count"] == 0
+    assert result["chunk_count"] == 0
+    assert result["last_sync_time"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_status_with_entries(tmp_path, monkeypatch):
+    log_data = {
+        "note1.md": {"mtime": 100.0, "ids": ["1", "2"]},
+        "note2.md": {"mtime": 200.0, "ids": ["3"]},
+    }
+    log_file = tmp_path / "sync_log.json"
+    log_file.write_text(json.dumps(log_data), encoding="utf-8")
+    monkeypatch.setattr(status, "SYNC_LOG_FILE", str(log_file))
+    monkeypatch.setattr(status, "VAULT_DIR", tmp_path)
+    monkeypatch.setattr(status, "INDEX_FILE", str(tmp_path / "index"))
+
+    result = await status.get_status()
+
+    assert result["log_exists"] is True
+    assert result["note_count"] == 2
+    assert result["chunk_count"] == 3
+    expected_time = datetime.fromtimestamp(200.0).strftime("%Y-%m-%d %H:%M:%S")
+    assert result["last_sync_time"] == expected_time


### PR DESCRIPTION
## Summary
- avoid `max()` on empty sync logs in `get_status`
- return zero stats when the sync log is empty
- add unit tests for empty and populated sync log scenarios

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684248faa58c8329b301bd88cbd5a249